### PR TITLE
Fix missing token fixtures for user roles

### DIFF
--- a/app/services/jwt_service.py
+++ b/app/services/jwt_service.py
@@ -8,7 +8,7 @@ def create_access_token(*, data: dict, expires_delta: timedelta = None):
     to_encode = data.copy()
     # Convert role to uppercase before encoding the JWT
     if 'role' in to_encode:
-        to_encode['role'] = to_encode['role'].upper()
+        to_encode['role'] = str(to_encode['role']).upper()
     expire = datetime.utcnow() + (expires_delta if expires_delta else timedelta(minutes=settings.access_token_expire_minutes))
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -261,3 +261,19 @@ def user_response_data():
 @pytest.fixture
 def login_request_data():
     return {"username": "john_doe_123", "password": "SecurePassword123!"}
+
+@pytest.fixture
+async def user_token(user):
+    payload = {"sub": str(user.id), "role": str(user.role).upper()}
+    return create_access_token(data=payload)
+
+@pytest.fixture
+async def admin_token(admin_user):
+    payload = {"sub": str(admin_user.id), "role": str(admin_user.role).upper()}
+    return create_access_token(data=payload)
+
+@pytest.fixture
+async def manager_token(manager_user):
+    payload = {"sub": str(manager_user.id), "role": str(manager_user.role).upper()}
+    return create_access_token(data=payload)
+


### PR DESCRIPTION
Fixes Issue #1 by adding fixtures for user_token, admin_token, and manager_token. These are now correctly generated using the create_access_token function, resolving AttributeErrors related to .upper() calls on UserRole.